### PR TITLE
Fix multiple servers support for client

### DIFF
--- a/shadowsocks/obfsplugin/obfs_tls.py
+++ b/shadowsocks/obfsplugin/obfs_tls.py
@@ -108,8 +108,10 @@ class tls_ticket_auth(plain.plain):
             host = self.server_info.obfs_param or self.server_info.host
             if host and host[-1] in string.digits:
                 host = ''
-            hosts = host.split(',')
-            host = random.choice(hosts)
+            if type(host) == list:
+                host = random.choice(host)
+            else:
+                host = random.choice(host.split(','))
             ext += self.sni(host)
             ext += b"\x00\x17\x00\x00"
             if host not in self.server_info.data.ticket_buf:


### PR DESCRIPTION
Original shadowsocks client (local.py) supports multiple servers (write all servers to an array in "server" directive in config.json).

This commit fixes the problem when using this feature, which raises an exception like:
```
2017-07-05 18:43:43 ERROR    tcprelay.py:1091 'list' object has no attribute 'split' when handling connection from 127.0.0.1:55412
```