### PR TITLE
Do not print password on startup

### DIFF
--- a/shadowsocks/local.py
+++ b/shadowsocks/local.py
@@ -46,8 +46,8 @@ def main():
         asyncdns.IPV6_CONNECTION_SUPPORT = False
 
     daemon.daemon_exec(config)
-    logging.info("local start with protocol[%s] password [%s] method [%s] obfs [%s] obfs_param [%s]" %
-            (config['protocol'], config['password'], config['method'], config['obfs'], config['obfs_param']))
+    logging.info("local start with protocol[%s] method [%s] obfs [%s] obfs_param [%s]" %
+            (config['protocol'], config['method'], config['obfs'], config['obfs_param']))
 
     try:
         logging.info("starting local at %s:%d" %

--- a/shadowsocks/server.py
+++ b/shadowsocks/server.py
@@ -102,8 +102,8 @@ def main():
             password = password_obfs
         a_config = config.copy()
         ipv6_ok = False
-        logging.info("server start with protocol[%s] password [%s] method [%s] obfs [%s] obfs_param [%s]" %
-                (protocol, password, method, obfs, obfs_param))
+        logging.info("server start with protocol[%s] method [%s] obfs [%s] obfs_param [%s]" %
+                (protocol, method, obfs, obfs_param))
         if 'server_ipv6' in a_config:
             try:
                 if len(a_config['server_ipv6']) > 2 and a_config['server_ipv6'][0] == "[" and a_config['server_ipv6'][-1] == "]":


### PR DESCRIPTION
Depending on system configuration, stdout may be logged and log files may be accessible to non-root user, password will be leaked in that case.